### PR TITLE
Implemented request rate throttling.

### DIFF
--- a/core/src/it/scala/com/github/pheymann/rrt/RequestThrottlingItSpec.scala
+++ b/core/src/it/scala/com/github/pheymann/rrt/RequestThrottlingItSpec.scala
@@ -1,0 +1,44 @@
+package com.github.pheymann.rrt
+
+import org.specs2.mutable.Specification
+
+class RequestThrottlingItSpec extends Specification {
+
+  val testName = "request-throttling-it-spec"
+
+  val serverConfig = newConfig(testName, "127.0.0.1", 10000, "127.0.0.1", 10001)
+
+  "The library" should {
+    "provide a config to throttle the maximum number of request" in new WithTestServices(serverConfig) {
+      val testCase = for {
+        names   <- genStaticData("Luke", "Boba", "Yoda", "Anakin", "Han", "C3PO", "R2D2", "ObiWan", "Padme", "Leia")
+        result  <- testGet { _ =>
+          s"/hello/${names()}"
+        }
+      } yield result
+
+      //warm-up
+      testCase.runSeq(serverConfig.withRepetitions(10000))
+
+      val t0Fast = System.currentTimeMillis()
+      val testConfigFast = serverConfig
+        .withRepetitions(10)
+        .withThrottling(10)
+
+      testCase.runSeq(testConfigFast)
+      val tDiffFast = System.currentTimeMillis() - t0Fast
+
+      val t0Slow = System.currentTimeMillis()
+      val testConfigSlow = serverConfig
+        .withRepetitions(10)
+        .withThrottling(1)
+
+      testCase.runSeq(testConfigSlow)
+      val tDiffSlow = System.currentTimeMillis() - t0Slow
+
+      println(s"fast: $tDiffFast ms - slow: $tDiffSlow ms")
+      tDiffFast < tDiffSlow
+    }
+  }
+
+}

--- a/core/src/main/scala/com/github/pheymann/rrt/TestConfig.scala
+++ b/core/src/main/scala/com/github/pheymann/rrt/TestConfig.scala
@@ -15,6 +15,7 @@ final case class TestConfig(
                              dbConfigOpt: Option[DatabaseConfig] = None,
 
                              repetitions: Int = 1,
+                             requestPerSecondOpt: Option[Int] = None,
                              timeout: FiniteDuration = 21400000.seconds
                            ) {
 
@@ -52,6 +53,13 @@ final case class TestConfig(
     * @return updated config
     */
   def withRepetitions(repetitions: Int): TestConfig = this.copy(repetitions = repetitions)
+
+  /** Sets the maximum number of requests per second.
+    *
+    * @param requestPerSecond maximum number of requests per second
+    * @return updated config
+    */
+  def withThrottling(requestPerSecond: Int): TestConfig = this.copy(requestPerSecondOpt = Some(requestPerSecond))
 
   /** Sets timeout to a new value (default `Long.MaxValue` nanoseconds).
     *

--- a/core/src/main/scala/com/github/pheymann/rrt/util/DataGeneratorSyntax.scala
+++ b/core/src/main/scala/com/github/pheymann/rrt/util/DataGeneratorSyntax.scala
@@ -7,6 +7,12 @@ trait DataGeneratorSyntax {
 
   implicit class DataGeneratorToOpt[A](gen: RandomValueGen[A]) {
 
+    /** Wrappes a `RandomValueGen` result into a `Option`. If it
+      * is a `Some` or `None` is decided randomly.
+      *
+      * @param rand implicit `RandomUtil`
+      * @return either a Some(value: A) or a None
+      */
     def toOpt(implicit rand: RandomUtil): Option[A] = {
       if (randBoolean)
         Some(gen())
@@ -18,9 +24,23 @@ trait DataGeneratorSyntax {
 
   implicit class DataGeneratorToSeq[A](gen: RandomValueGen[A]) {
 
+    /** Generates a `Seq` of values from `RandomValueGen` with a defined
+      * maximum size.
+      *
+      * @param maxSize Seq.length <= maxSize
+      * @param rand implicit `RandomUtil`
+      * @return a `Seq` of random values: A with random but bounded size
+      */
     def toSeq(maxSize: Int)
              (implicit rand: RandomUtil): Seq[A] = (0 to rand.nextPositiveInt(maxSize)).map(_ => gen())
 
+    /** Generates a `Seq` of values from `RandomValueGen` with a defined
+      * maximum size and at least one element.
+      *
+      * @param maxSize 0 < Seq.length <= maxSize
+      * @param rand implicit `RandomUtil`
+      * @return a `Seq` of random values: A with random but bounded size
+      */
     def toNonEmptySeq(maxSize: Int)
                      (implicit rand: RandomUtil): Seq[A] = (0 to rand.nextPositiveInt(maxSize)).map(_ => gen())
 


### PR DESCRIPTION
You can define now a `requestPerSecond` which throttles the request rate. This parameter defined an upper bound (a max value). The library is generate at most `requestPerSecond`.

With this parameter you can ensure to not overload your test system.