### PR TITLE
Added configs to ignore Json keys and there values.

### DIFF
--- a/core/src/it/scala/com/github/pheymann/rrt/CleanedResponseBodyItSpec.scala
+++ b/core/src/it/scala/com/github/pheymann/rrt/CleanedResponseBodyItSpec.scala
@@ -1,0 +1,50 @@
+package com.github.pheymann.rrt
+
+import org.specs2.mutable.Specification
+
+class CleanedResponseBodyItSpec extends Specification {
+
+  sequential
+
+  val testName = "cleaned-body-it-spec"
+  val testConfig = newConfig(testName, "127.0.0.1", 9000, "127.0.0.1", 9001)
+
+  "The response bodies" should {
+    "be cleaned by Json key if at least one is set" in new WithTestServices(testConfig) {
+      val testCase = for {
+        statics <- genStaticData("Luke", "Boba", "Yoda", "Anakin", "Han", "C3PO")
+        result  <- testGet { _ =>
+          s"/hello/json/differ/${statics()}"
+        }
+      } yield result
+
+      checkAndLog(testCase.runSeq(testConfig.withJsonIgnore(List("test")))) should beTrue
+    }
+
+    "be cleaned by regex if at least one is set" in new WithTestServices(testConfig) {
+      val testCase = for {
+        statics <- genStaticData("Luke", "Boba", "Yoda", "Anakin", "Han", "C3PO")
+        result  <- testGet { _ =>
+          s"/hello/json/differ/${statics()}"
+        }
+      } yield result
+
+      checkAndLog(testCase.runSeq(testConfig.withIgnoreByRegex(List("\"test\":[0-9]*")))) should beTrue
+    }
+
+    "be cleaned by regex and Json key" in new WithTestServices(testConfig) {
+      val testCase = for {
+        statics <- genStaticData("Luke", "Boba", "Yoda", "Anakin", "Han", "C3PO")
+        result  <- testGet { _ =>
+          s"/hello/json/differ/${statics()}"
+        }
+      } yield result
+
+      checkAndLog(testCase.runSeq(testConfig
+        .withIgnoreByRegex(List("\"test\":[0-9]*"))
+        .withJsonIgnore(List("message"))
+      )) should beTrue
+    }
+  }
+
+}

--- a/core/src/it/scala/com/github/pheymann/rrt/CleanedResponseBodyItSpec.scala
+++ b/core/src/it/scala/com/github/pheymann/rrt/CleanedResponseBodyItSpec.scala
@@ -18,7 +18,7 @@ class CleanedResponseBodyItSpec extends Specification {
         }
       } yield result
 
-      checkAndLog(testCase.runSeq(testConfig.withJsonIgnore(List("test")))) should beTrue
+      checkAndLog(testCase.runSeq(testConfig.withIgnoreJsonKeys(List("test")))) should beTrue
     }
 
     "be cleaned by regex if at least one is set" in new WithTestServices(testConfig) {
@@ -42,7 +42,7 @@ class CleanedResponseBodyItSpec extends Specification {
 
       checkAndLog(testCase.runSeq(testConfig
         .withIgnoreByRegex(List("\"test\":[0-9]*"))
-        .withJsonIgnore(List("message"))
+        .withIgnoreJsonKeys(List("message"))
       )) should beTrue
     }
   }

--- a/core/src/it/scala/com/github/pheymann/rrt/TestService.scala
+++ b/core/src/it/scala/com/github/pheymann/rrt/TestService.scala
@@ -42,7 +42,20 @@ object TestService {
           if (failing)
             errorResponse
           else
-            HttpEntity(`text/html(UTF-8)`, "{\"message\": \"hello " + name + "\"}")
+            HttpEntity(`text/html(UTF-8)`, "{\"message\": \"hello " + name + "\",\"test\":01234}")
+        }
+      }
+    } ~
+    path("hello" / "json" / "differ" / Segment) { name =>
+      get {
+        if (log.isDebugEnabled)
+          log.debug(s"GET:$port /hello/json - name = $name")
+
+        complete {
+          if (failing)
+            errorResponse
+          else
+            HttpEntity(`text/html(UTF-8)`, "{\"message\": \"hello " + name + "\",\"test\":" + System.currentTimeMillis.toString + "}")
         }
       }
     } ~

--- a/core/src/main/scala/com/github/pheymann/rrt/TestConfig.scala
+++ b/core/src/main/scala/com/github/pheymann/rrt/TestConfig.scala
@@ -11,7 +11,7 @@ final case class TestConfig(
 
                              headers: List[(String, String)] = Nil,
                              bodyRemovals: List[String] = Nil,
-                             jsonIgnore: List[String] = Nil,
+                             jsonIgnoreKeys: List[String] = Nil,
                              showDiffs: Boolean = false,
 
                              dbConfigOpt: Option[DatabaseConfig] = None,
@@ -40,18 +40,18 @@ final case class TestConfig(
   /** Adds regex patterns which remove elements from the response body (entity). This can
     * be useful if the response contains some values which differ for two service instances.
     *
-    * @param ignoreRegexes regex pattern
+    * @param regexes regex pattern
     * @return updated config
     */
-  def withIgnoreByRegex(ignoreRegexes: List[String]): TestConfig = this.copy(bodyRemovals = ignoreRegexes)
+  def withIgnoreByRegex(regexes: List[String]): TestConfig = this.copy(bodyRemovals = regexes)
 
   /** Adds a `List` of Json keys which will be removed from the response bodies together with the values. This can
     * be useful if the response contains some values which differ for two service instances.
     *
-    * @param ignores json key
+    * @param keys json keys
     * @return updated config
     */
-  def withJsonIgnore(ignores: List[String]): TestConfig = this.copy(jsonIgnore = ignores)
+  def withIgnoreJsonKeys(keys: List[String]): TestConfig = this.copy(jsonIgnoreKeys = keys)
 
   /** Show differences of response json rather than the whole bodies.
     *

--- a/core/src/main/scala/com/github/pheymann/rrt/TestConfig.scala
+++ b/core/src/main/scala/com/github/pheymann/rrt/TestConfig.scala
@@ -11,6 +11,7 @@ final case class TestConfig(
 
                              headers: List[(String, String)] = Nil,
                              bodyRemovals: List[String] = Nil,
+                             jsonIgnore: List[String] = Nil,
                              showDiffs: Boolean = false,
 
                              dbConfigOpt: Option[DatabaseConfig] = None,
@@ -33,7 +34,24 @@ final case class TestConfig(
     * @param removals regex pattern
     * @return updated config
     */
+  @deprecated("use `withIgnoreByRegex` instead")
   def withBodyRemovals(removals: List[String]): TestConfig = this.copy(bodyRemovals = removals)
+
+  /** Adds regex patterns which remove elements from the response body (entity). This can
+    * be useful if the response contains some values which differ for two service instances.
+    *
+    * @param ignoreRegexes regex pattern
+    * @return updated config
+    */
+  def withIgnoreByRegex(ignoreRegexes: List[String]): TestConfig = this.copy(bodyRemovals = ignoreRegexes)
+
+  /** Adds a `List` of Json keys which will be removed from the response bodies together with the values. This can
+    * be useful if the response contains some values which differ for two service instances.
+    *
+    * @param ignores json key
+    * @return updated config
+    */
+  def withJsonIgnore(ignores: List[String]): TestConfig = this.copy(jsonIgnore = ignores)
 
   /** Show differences of response json rather than the whole bodies.
     *

--- a/core/src/main/scala/com/github/pheymann/rrt/util/BodyAsStringComparison.scala
+++ b/core/src/main/scala/com/github/pheymann/rrt/util/BodyAsStringComparison.scala
@@ -11,14 +11,17 @@ object BodyAsStringComparison {
   def stringComparison(actual: String,
                        expected: String,
                        config: TestConfig): Option[ComparisonFailure] = {
-    val actualCleanedBody   = cleanBody(actual, config.bodyRemovals)
-    val expectedCleanedBody = cleanBody(expected, config.bodyRemovals)
+    val actualCleanedByKey   = cleanBodyByKey(actual, config.jsonIgnore)
+    val expectedCleanedByKey = cleanBodyByKey(expected, config.jsonIgnore)
+
+    val actualCleaned   = cleanBodyByRegex(actualCleanedByKey, config.bodyRemovals)
+    val expectedCleaned = cleanBodyByRegex(expectedCleanedByKey, config.bodyRemovals)
 
     if (config.showDiffs)
-      jsonComparison(actualCleanedBody, expectedCleanedBody)
+      jsonComparison(actualCleaned, expectedCleaned)
     else {
-      if (actualCleanedBody != expectedCleanedBody)
-        Some(FailureWithValues("body", actualCleanedBody, expectedCleanedBody))
+      if (actualCleaned != expectedCleaned)
+        Some(FailureWithValues("body", actualCleaned, expectedCleaned))
       else
         None
     }
@@ -42,11 +45,24 @@ object BodyAsStringComparison {
 
   private final val EmptyReplacement = ""
 
-  private[util] def cleanBody(body: String, removals: List[String]): String = {
+  private[util] def cleanBodyByKey(body: String, keys: List[String]): String = {
     var cleanedBody = body
 
-    for (removal <- removals)
-      cleanedBody = cleanedBody.replaceAll(removal, EmptyReplacement)
+    def innerKeyRegex(key: String): String = "\"" + key + "\"\\s*:\\s*(\".*\")?([0-9]*)?(null)?(\\[.*\\])?(\\{.*\\})?\\s*,"
+    def lastKeyRegex(key: String): String = "(,)?\"" + key + "\"\\s*:\\s*(\".*\")?([0-9]*)?(null)?(\\[.*\\])?(\\{.*\\})?\\s*\\}"
+
+    for (key <- keys) {
+      cleanedBody = cleanedBody.replaceAll(innerKeyRegex(key), EmptyReplacement)
+      cleanedBody = cleanedBody.replaceAll(lastKeyRegex(key), "}")
+    }
+    cleanedBody
+  }
+
+  private[util] def cleanBodyByRegex(body: String, regexes: List[String]): String = {
+    var cleanedBody = body
+
+    for (regex <- regexes)
+      cleanedBody = cleanedBody.replaceAll(regex, EmptyReplacement)
     cleanedBody
   }
 

--- a/core/src/main/scala/com/github/pheymann/rrt/util/BodyAsStringComparison.scala
+++ b/core/src/main/scala/com/github/pheymann/rrt/util/BodyAsStringComparison.scala
@@ -11,8 +11,8 @@ object BodyAsStringComparison {
   def stringComparison(actual: String,
                        expected: String,
                        config: TestConfig): Option[ComparisonFailure] = {
-    val actualCleanedByKey   = cleanBodyByKey(actual, config.jsonIgnore)
-    val expectedCleanedByKey = cleanBodyByKey(expected, config.jsonIgnore)
+    val actualCleanedByKey   = cleanBodyByKey(actual, config.jsonIgnoreKeys)
+    val expectedCleanedByKey = cleanBodyByKey(expected, config.jsonIgnoreKeys)
 
     val actualCleaned   = cleanBodyByRegex(actualCleanedByKey, config.bodyRemovals)
     val expectedCleaned = cleanBodyByRegex(expectedCleanedByKey, config.bodyRemovals)

--- a/core/src/test/scala/com/github/pheymann/rrt/util/BodyAsStringComparisonSpec.scala
+++ b/core/src/test/scala/com/github/pheymann/rrt/util/BodyAsStringComparisonSpec.scala
@@ -11,12 +11,46 @@ class BodyAsStringComparisonSpec extends Specification {
   val testConfig = newConfig("string-comparison-spec", "", 80, "", 80)
 
   "The body-as-string comparison" should {
-    "clean the response entity (body), removing defined `String` segments" in {
+    "clean the response entity (body), removing defined `String` segments by regex" in {
       val body = "{\"random_id\":23432j34343kkj3432,\"value\":\"hello world\"}"
 
       val bodyRemovals = List("\"random_id\":[0-9a-z]*,")
 
-      cleanBody(body, bodyRemovals) must beEqualTo("{\"value\":\"hello world\"}")
+      cleanBodyByRegex(body, bodyRemovals) must beEqualTo("{\"value\":\"hello world\"}")
+    }
+
+    "clean the response Json (body) by defined keys" in {
+      val body0 = "{\"test0\"  :\"aaaa\",\"test1\":\"bbbbbb\"}"
+
+      cleanBodyByKey(body0, List("test0")) must beEqualTo("{\"test1\":\"bbbbbb\"}")
+
+      val body1 = "{\"test0\"  :9845048,\"test1\":\"bbbbbb\"}"
+
+      cleanBodyByKey(body1, List("test0")) must beEqualTo("{\"test1\":\"bbbbbb\"}")
+
+      val body2 = "{\"test0\"  :null,\"test1\":\"bbbbbb\"}"
+
+      cleanBodyByKey(body2, List("test0")) must beEqualTo("{\"test1\":\"bbbbbb\"}")
+
+      val body3 = "{\"test0\"  :[0,1,2,\"a\"],\"test1\":\"bbbbbb\"}"
+
+      cleanBodyByKey(body3, List("test0")) must beEqualTo("{\"test1\":\"bbbbbb\"}")
+
+      val body4 = "{\"test0\"  :{\"a\":null},\"test1\":\"bbbbbb\"}"
+
+      cleanBodyByKey(body4, List("test0")) must beEqualTo("{\"test1\":\"bbbbbb\"}")
+
+      val body5 = "{\"test0\":{\"a\":null},\"test1\":\"bbbbbb\"}"
+
+      cleanBodyByKey(body5, List("test1")) must beEqualTo("{\"test0\":{\"a\":null}}")
+
+      val body6 = "{\"test0\":{\"a\":null}}"
+
+      cleanBodyByKey(body6, List("test0")) must beEqualTo("{}")
+
+      val body7 = "{\"test0\":{\"a\":null},\"test1\":\"bbbbbb\",\"test2\":\"ccccc\"}"
+
+      cleanBodyByKey(body7, List("test1")) must beEqualTo("{\"test0\":{\"a\":null},\"test2\":\"ccccc\"}")
     }
 
     "check if the response bodies are different" in {


### PR DESCRIPTION
Now you can set a `List` of Json keys like this:

```Scala
config.withIgnoreJsonKeys(List("key0"))
```

which will remove the key and the corresponding value from the response Jsons:

```Json
{"key0":0,"key1":1} -> {"key1":1}
```

Furthermore, I added another function `withIgnoreByRegex` which replaces the old `withBodyRemovals`. The old function is still available.

