### PR TITLE
Hotfix/2.2.1 Fixed checkResult and failed tries calculation.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys._
 val commonSettings = Seq(
   organization := "com.github.pheymann",
   scalaVersion := "2.11.8",
-  version      := "2.2.0",
+  version      := "2.2.1",
 
   sonatypeProfileName := "pheymann",
   pomExtra in Global := {

--- a/core/src/it/scala/com/github/pheymann/rrt/ExceptionInTestRunnerItSpec.scala
+++ b/core/src/it/scala/com/github/pheymann/rrt/ExceptionInTestRunnerItSpec.scala
@@ -1,0 +1,19 @@
+package com.github.pheymann.rrt
+
+import org.specs2.mutable.Specification
+
+class ExceptionInTestRunnerItSpec extends Specification {
+
+  val testName = "test-runner-exception-it-spec"
+  val testConfig = newConfig(testName, "127.0.0.1", 10000, "127.0.0.1", 10001)
+    .withRepetitions(1)
+
+  "If an `Exception` occurs in `TestRunner` it" should {
+    "mark the test case as failed and stop the process" in new WithTestServices(testConfig) {
+      val testCase = testGet(_ => throw new IllegalArgumentException("expected"))
+
+      checkAndLog(testCase.runSeq(testConfig)) should beFalse
+    }
+  }
+
+}

--- a/core/src/main/scala/com/github/pheymann/rrt/RefactoringTest.scala
+++ b/core/src/main/scala/com/github/pheymann/rrt/RefactoringTest.scala
@@ -14,9 +14,7 @@ trait RefactoringTest {
     testCase.foldMap(TestActionInterpreter.interpreter(comparison, config))
   }
 
-  def checkResult(result: TestResult): Boolean = {
-    result.failedTries == 0
-  }
+  def checkResult(result: TestResult): Boolean = result.successful
 
   private final val PrintPrefix = "  "
 

--- a/core/src/main/scala/com/github/pheymann/rrt/TestRunner.scala
+++ b/core/src/main/scala/com/github/pheymann/rrt/TestRunner.scala
@@ -66,7 +66,7 @@ object TestRunner {
 
     val comparisons = comparisonsBuilder.result()
     val failedComparisons = comparisons.filterNot(_._2.areEqual)
-    val failedTries = failedComparisons.length
+    val failedTries = failedComparisons.length + (if (failed) 1 else 0)
 
     TestResult(config.name, !failed && failedTries == 0, config.repetitions - failedTries, failedTries, failedComparisons)
   }

--- a/core/src/test/scala/com/github/pheymann/rrt/TestRunnerSpec.scala
+++ b/core/src/test/scala/com/github/pheymann/rrt/TestRunnerSpec.scala
@@ -49,7 +49,7 @@ class TestRunnerSpec extends Specification {
       val testRest = () => Future.failed(new IllegalArgumentException("expected"))
 
       TestRunner.runSequential(BodyAsStringComparison.stringComparison, testConfig, RandomUtil, "TEST-GET")(testRest) should beEqualTo(
-        TestResult(testConfig.name, false, 1, 0, Nil)
+        TestResult(testConfig.name, false, 0, 1, Nil)
       )
     }
   }

--- a/plugin/src/main/scala/com/github/pheymann/rrt/plugin/package.scala
+++ b/plugin/src/main/scala/com/github/pheymann/rrt/plugin/package.scala
@@ -12,7 +12,7 @@ package object plugin {
     resourceDirectory in RestRefactoringTest := baseDirectory.value / "test-conf"
   )
 
-  val rrtVersion = "2.2.0"
+  val rrtVersion = "2.2.1"
 
   val rrtCore = "com.github.pheymann" %% "rrt-core" % rrtVersion
   val rrtPlay = "com.github.pheymann" %% "rrt-play" % rrtVersion


### PR DESCRIPTION
`checkResult` only checked `failedTries == 0`, but as the calculation of this number was wrong it marked failed tests as successful if no comparison failed but an exception was raised in `TestRunner`.